### PR TITLE
Fix duplicate keyword on completion

### DIFF
--- a/Client/VsCode/.gitignore
+++ b/Client/VsCode/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 server
+.vscode-test

--- a/RhetosLanguageServer/Services/TextDocumentService.cs
+++ b/RhetosLanguageServer/Services/TextDocumentService.cs
@@ -99,7 +99,22 @@ namespace RhetosLanguageServer
                     conceptsInfoMetadataToApply = conceptsInfoMetadataToApply.Where(x => x.Members.Count > 0 && x.Members[0].IsConceptInfo && x.Members[0].ValueType.IsAssignableFrom(context.GetType()));
                 else
                     conceptsInfoMetadataToApply = conceptsInfoMetadataToApply.Where(x => x.Members.Count > 0 && !x.Members[0].IsConceptInfo);
-                return new CompletionList(conceptsInfoMetadataToApply.Select(x => new CompletionItem { Label = x.Keyword, Kind = CompletionItemKind.Keyword, Detail = x.GetUserDescription(false) }));
+
+                List<CompletionItem> completionsList = new List<CompletionItem>();
+                foreach(var conceptInfo in conceptsInfoMetadataToApply)
+                {
+                    if(!completionsList.Exists(x => x.Label == conceptInfo.Keyword))
+                    {
+                        completionsList.Add(new CompletionItem
+                        {
+                            Label = conceptInfo.Keyword,
+                            Kind = CompletionItemKind.Keyword,
+                            Detail = conceptInfo.GetUserDescription(false)
+                        });
+                    }
+                }
+
+                return new CompletionList(completionsList);
             }
             else
             {


### PR DESCRIPTION
When I type a keyword like "Sql", there are 3 keyword same **SqlDependsOn**, it could make user confused.

If each keyword has different description, we could group them into one.

This is related to issue fixes #2 